### PR TITLE
Fix: Extract filePath from response

### DIFF
--- a/static/js/fileUpload.js
+++ b/static/js/fileUpload.js
@@ -8,14 +8,14 @@ $(function(){
       onComplete: function(file, response){
         // Require the editor..
         var padeditor = require('ep_etherpad-lite/static/js/pad_editor').padeditor;
-        
+
         // result i.e. "/up/c79133b2c8a97533cc397f8d325ce17a.jpg", trimmed whitespace
-        var filePath = response.replace(/^\s+|\s+$/g, '');
+        var filePath = response.slice(response.indexOf("/up")).trim();
         // "http://example.com/subfolder/p/padID" -> "http://example.com/subfolder"
-        var etherpadRoot = document.location.href.replace(/\/p\/[^\/]+$/,'');
+        var etherpadRoot = document.location.href.slice(0, document.location.href.indexOf("/p/"));
         // "http://example.com/subfolder/up/c79133b2c8a97533cc397f8d325ce17a.jpg"
         var fileUri = etherpadRoot + filePath;
-        
+
         // Puts the actual URL in the pad..
         padeditor.ace.replaceRange(undefined, undefined, " " + fileUri + " ");
         // Put the caret back into the pad


### PR DESCRIPTION
In some cases (at least in my case 'https://sub.example.com:9001/p/mytest' ) it is possible that the response
variable already contains schema, domain and port. The filePath should start with "/up".