### PR TITLE
ajax file upload using formData with fallback to hidden iframe

### DIFF
--- a/static/js/fileUpload.js
+++ b/static/js/fileUpload.js
@@ -6,6 +6,7 @@ $(function(){
      */
     function AjaxUploadNew(btn, conf) {
             if (btn instanceof jQuery) { btn = btn[0]; } // unwrap
+            if (!btn) { return; } // if in admin page
 
             btn.addEventListener("click", (e) => {
                 e.preventDefault();

--- a/static/js/fileUpload.js
+++ b/static/js/fileUpload.js
@@ -1,10 +1,67 @@
-$(function(){  
-    var info = {  
+$(function(){
+
+    /**
+     * New Ajax Upload File
+     * Use FormData instead of hidden iframe, works on Chrome & FF.
+     */
+    function AjaxUploadNew(btn, conf) {
+            if (btn instanceof jQuery) { btn = btn[0]; } // unwrap
+
+            btn.addEventListener("click", (e) => {
+                e.preventDefault();
+
+                let fileInput = document.createElement("input");
+                fileInput.setAttribute("type", "file");
+                fileInput.onchange = function(e2) {
+                    // chosen a file
+                    let file = fileInput.files[0];
+                    let ext = getExt(file.name);
+                    conf.onChange && conf.onChange(file, ext);
+
+                    // construct form datagram
+                    let formData = new FormData();
+                    formData.append(conf.name, file);
+
+                    // ajax post
+                    var xhr = new XMLHttpRequest();
+                    xhr.open('POST', conf.action, true);
+                    xhr.onreadystatechange = function () {
+                        if(xhr.readyState === 4 && xhr.status === 200) {
+                            let url = xhr.responseText.match(/<body>(.+)<\/body>/i)[1];
+                            console.log(url);
+                            conf.onComplete && conf.onComplete(file, url);
+                        }
+                    };
+
+                    // cancel submit if callback returns false
+                    if (conf.onSubmit) {
+                        let ret = conf.onSubmit(file, ext);
+                        if (typeof ret === "undefined" || !!ret) {
+                            xhr.send(formData);
+                        } else {
+                            xhr.abort();
+                        }
+                    } else {
+                        xhr.send(formData);
+                    }
+                }
+
+                // open file dialog
+                fileInput.click();
+            });
+
+            // get file extension
+            function getExt(file){
+                return (-1 !== file.indexOf('.')) ? file.replace(/.*[.]/, '') : '';
+            }
+        }
+
+    var info = {
       action: '../fileUpload/',
       name: 'uploadfile', 
       onSubmit: function(file, ext){ // On submit we do nothing, it'd be nice to do something but mheh..
       //console.log('Starting...');
-      },  
+      },
       onComplete: function(file, response){
         // Require the editor..
         var padeditor = require('ep_etherpad-lite/static/js/pad_editor').padeditor;
@@ -20,8 +77,14 @@ $(function(){
         padeditor.ace.replaceRange(undefined, undefined, " " + fileUri + " ");
         // Put the caret back into the pad
         padeditor.ace.focus();
-      }  
+      }
     };
 
-    new AjaxUpload($('#uploadFileSubmit'), info);  
+    if (!! window.FormData) {
+        // ajax upload from formData
+        AjaxUploadNew($('#uploadFileSubmit'), info);
+    } else {
+        // ajax upload to hidden iframe
+        new AjaxUpload($('#uploadFileSubmit'), info);
+    }
 });


### PR DESCRIPTION
This PR is to fix the issue with iframe access lockdown by modern browers.

Even though iframe and parent html are under the same origin, browsers without enabling CORS won't be able to modified children iframe's content.
Instead, you get errors like:
> Blocked a frame with origin xxxxxxxxx from accessing a cross-origin frame.

This PR uses ajax request with simulated form data upload via **formData()** so to bypass the upload-to-hidden-iframe scheme completely.

For older browser that doesn't support **formData()**, this PR allows fallbacking to iframe uploading scheme.